### PR TITLE
scale not clear power by 75 percent

### DIFF
--- a/api/esprr_api/compute.py
+++ b/api/esprr_api/compute.py
@@ -101,8 +101,8 @@ def compute_total_system_power(
         else:
             out += part  # type: ignore
     # hack to make output more consistent with actuals in not-clear conditions
-    not_clear = out["ac_power"] < 0.99 * out["clearsky_ac_power"]
-    out.loc[not_clear, "ac_power"] *= 0.75
+    clear = out["ac_power"] > 0.99 * out["clearsky_ac_power"]
+    out["ac_power"] = out["ac_power"].where(clear, out["ac_power"] * 0.75)
     return out
 
 

--- a/api/esprr_api/compute.py
+++ b/api/esprr_api/compute.py
@@ -102,7 +102,7 @@ def compute_total_system_power(
             out += part  # type: ignore
     # hack to make output more consistent with actuals in not-clear conditions
     clear = out["ac_power"] > 0.99 * out["clearsky_ac_power"]
-    out["ac_power"] = out["ac_power"].where(clear, other=out["ac_power"] * 0.75)
+    out["ac_power"] = out["ac_power"].where(clear, other=out["ac_power"] * 0.75)  # type: ignore
     return out
 
 

--- a/api/esprr_api/compute.py
+++ b/api/esprr_api/compute.py
@@ -102,7 +102,10 @@ def compute_total_system_power(
             out += part  # type: ignore
     # hack to make output more consistent with actuals in not-clear conditions
     clear = out["ac_power"] > 0.99 * out["clearsky_ac_power"]
-    out["ac_power"] = out["ac_power"].where(clear, other=out["ac_power"] * 0.75)  # type: ignore
+    out["ac_power"] = out["ac_power"].where(
+        clear,
+        other=out["ac_power"] * 0.75
+    )  # type: ignore
     return out
 
 

--- a/api/esprr_api/compute.py
+++ b/api/esprr_api/compute.py
@@ -101,7 +101,7 @@ def compute_total_system_power(
         else:
             out += part  # type: ignore
     # hack to make output more consistent with actuals in not-clear conditions
-    not_clear = out["ac_power"] < 0.99*out["clearsky_ac_power"]
+    not_clear = out["ac_power"] < 0.99 * out["clearsky_ac_power"]
     out.loc[not_clear, "ac_power"] *= 0.75
     return out
 

--- a/api/esprr_api/compute.py
+++ b/api/esprr_api/compute.py
@@ -103,8 +103,7 @@ def compute_total_system_power(
     # hack to make output more consistent with actuals in not-clear conditions
     clear = out["ac_power"] > 0.99 * out["clearsky_ac_power"]
     out["ac_power"] = out["ac_power"].where(
-        clear,
-        other=out["ac_power"] * 0.75
+        clear, other=out["ac_power"] * 0.75
     )  # type: ignore
     return out
 

--- a/api/esprr_api/compute.py
+++ b/api/esprr_api/compute.py
@@ -102,7 +102,7 @@ def compute_total_system_power(
             out += part  # type: ignore
     # hack to make output more consistent with actuals in not-clear conditions
     clear = out["ac_power"] > 0.99 * out["clearsky_ac_power"]
-    out["ac_power"] = out["ac_power"].where(clear, out["ac_power"] * 0.75)
+    out["ac_power"] = out["ac_power"].where(clear, other=out["ac_power"] * 0.75)
     return out
 
 

--- a/api/esprr_api/compute.py
+++ b/api/esprr_api/compute.py
@@ -100,6 +100,9 @@ def compute_total_system_power(
             out = part
         else:
             out += part  # type: ignore
+    # hack to make output more consistent with actuals in not-clear conditions
+    not_clear = out["ac_power"] < 0.99*out["clearsky_ac_power"]
+    out.loc[not_clear, "ac_power"] *= 0.75
     return out
 
 


### PR DESCRIPTION
Jenika reports that bias during non-clear conditions is significantly reduced by simply scaling the output by 75%.